### PR TITLE
Tickets are sent, hesk replace the spanish characters for other

### DIFF
--- a/tickets/API/Server.cs
+++ b/tickets/API/Server.cs
@@ -200,7 +200,7 @@ namespace tickets.API
 
             string token = node.GetAttributeValue("value", "0");
 
-            Encoding encoder = Encoding.GetEncoding("ISO-8859-1");
+            Encoding encoder = Encoding.GetEncoding("utf-8");
 
             form.Headers.Add("Cookie", cookie);
             form.Headers.ContentType.CharSet = "ISO-8859-1";


### PR DESCRIPTION
The issue now is that the Spanish characters are replaced for a rare one on hesk, even tho locally the acute accent is stored normally and we can see it